### PR TITLE
Add docker support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,14 @@
 #
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 1
+version: 2
 jobs:
   build:
+    branches:
+      ignore:
+        - publish-dockerhub
     docker:
-      - image: circleci/node:7.10
+      - image: circleci/node:6.14.2
     working_directory: ~/repo
 
     steps:
@@ -28,3 +31,43 @@ jobs:
       - run: yarn test_coverage
       - store_artifacts:
           path: coverage/
+
+  publish-docker-image:
+    docker:
+      - image: docker:18.05.0-ce-git
+    working_directory: /app
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build image
+          command: |
+            docker build -t feature-express .
+      - run:
+          name: Tag image
+          command: |
+            PACKAGE_VERSION=$(cat package.json \
+              | grep version \
+              | head -1 \
+              | awk -F: '{ print $2 }' \
+              | sed 's/[",\t ]//g')
+            docker tag feature-express $DOCKER_USER_ID/feature-express:latest
+            docker tag feature-express $DOCKER_USER_ID/feature-express:$PACKAGE_VERSION
+      - run:
+          name: Login in Dockerhub
+          command: |
+            docker login -u $DOCKER_USER_ID -p $DOCKER_PASS
+      - run:
+          name: Push to Dockerhub
+          command: |
+            docker push $DOCKER_USER_ID/feature-express
+
+workflows:
+  version: 2
+  publish-docker-image:
+    jobs:
+      - publish-docker-image:
+          filters:
+            branches:
+              only:
+                - publish-dockerhub

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+README.md
+npm-debug.log
+.gitignore
+.circleci/
+node_modules/
+test/
+features-example/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:6.14.2-alpine
+
+WORKDIR /opt/app
+COPY . /opt/app
+RUN apk add --no-cache tini && npm install --production
+
+USER node
+ENTRYPOINT ["/sbin/tini", "--"]
+
+EXPOSE 3000
+CMD ["node", "bin/global-feature-express.js", "/opt/app/features/"]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ $ feature-express ./YOUR-FEATURES-FOLDER/
  ```
  ## See your Features on HTML
 After running the command, your console will generate a url to see your features **"Feature-Express is running at http://localhost:4444/"**
+
+## Running with Docker
+
+### To run feature-express docker image on port 3000 and mapping features folder
+```
+docker pull menezes-ssz/feature-express:latest
+docker run -p 3000:3000 -v ABSOULUTE_PATH_FOR_YOUR_FEATURES_FOLDER:/opt/app/features/ menezes-ssz/feature-express
+```
+
+### To change PORT and LANG of feature-expresss
+```
+docker run -p 3000:3001 -e LANG=en -e PORT=3001 -v ABSOULUTE_PATH_FOR_YOUR_FEATURES_FOLDER:/opt/app/features/ menezes-ssz/feature-express
+```
+
 # Laguage
 
 * Express-Feature only support portuguese (pt), spanish (es) and english (en) language at the moment.

--- a/bin/global-feature-express.js
+++ b/bin/global-feature-express.js
@@ -5,8 +5,8 @@ let reader = require('../lib/reader.js');
 let app = express();
 let featurebookEndPoint = '/';
 let envPath = process.argv[2];
-let language = process.argv[3] == null ? 'en' : process.argv[3];
-let port = process.argv[4] == null ? 3000 :  process.argv[4];
+let language = process.argv[3] || process.env.LANG || 'en';
+let port = process.argv[4] || process.env.PORT || 3000;
 
 let path = require('path');
 


### PR DESCRIPTION
Hello, as I mentioned in the issue #8, this PR add Docker support for the project. How the publication works for Dockerhub is quite simple, just push to the `publish-dockerhub` branch (This can change and be another branch, for example `master`, only update circleci config for this) and the image is updated in Dockerhub with the version defined in package.json. But, for this to work it is necessary that some actions be done. 
1. A project maintainer create an account in [DockerHub](https://hub.docker.com/) and a repository for the feature-express. In the documentation of how to run with Docker, i predicted that the user id would be _menezes-ssz_, if it is different, it is necessary to update the documentation.
2. Configure some environment variables in CircleCI
2.1 `DOCKER_USER_ID`= User id of the account created in Dockerhub
2.2 `DOCKER_PASS`=User password of the account created in Dockerhub

Also there is already a test image published in my Dockerhub, if you want to view/test, click [here](https://hub.docker.com/r/leonardovillela/feature-express/). 