### PR TITLE
Use the compatible Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.14.2-alpine
+FROM node:8-alpine
 
 WORKDIR /opt/app
 COPY . /opt/app


### PR DESCRIPTION
# Error with Node v6

```
$ docker run -p 3000:3000 -v `pwd`:/opt/app/features feature-express

/opt/app/lib/reader.js:5
let files = async (featuresPath) => {
                  ^

SyntaxError: Unexpected token (
    at createScript (vm.js:56:10)
    at Object.runInThisContext (vm.js:97:10)
    at Module._compile (module.js:549:28)
    at Object.Module._extensions..js (module.js:586:10)
    at Module.load (module.js:494:32)
    at tryModuleLoad (module.js:453:12)
    at Function.Module._load (module.js:445:3)
    at Module.require (module.js:504:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/opt/app/bin/global-feature-express.js:5:16)
```

Works well with Node v8